### PR TITLE
Remove binstubs from shipped version of gem

### DIFF
--- a/omniauth-sageone.gemspec
+++ b/omniauth-sageone.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/jetbuilt/omniauth-sageone'
   gem.licenses      = 'MIT'
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.name          = 'omniauth-sageone'
   gem.require_paths = ['lib']


### PR DESCRIPTION
As far as I can see they are not part of gem, but rather development-related.

The problem is that when adding to a project, they conflict with real binstubs coming from these libraries, resulting in a warning from Bundler:

```
The `rspec` executable in the `omniauth-sageone` gem is being loaded, but it's also present in other gems (rspec-core)
...
```